### PR TITLE
added cutting support for the QL-550

### DIFF
--- a/brother_ql/devicedependent.py
+++ b/brother_ql/devicedependent.py
@@ -135,6 +135,7 @@ modesetting = [
 ]
 
 cuttingsupport = [
+  'QL-550',
   'QL-560',
   'QL-570',
   'QL-580N',


### PR DESCRIPTION
I have tested the Brother P-touch QL-550 using 62mm continuous paper. Cutting support has been added in this request. Thanks for the great package.