### PR TITLE
Speed up implementation

### DIFF
--- a/brother_ql/brother_ql_create.py
+++ b/brother_ql/brother_ql_create.py
@@ -35,7 +35,7 @@ def main():
     parser.add_argument('--model', '-m', default='QL-500', help='The printer model to use. Check available ones with `brother_ql_info list-models`.')
     parser.add_argument('--label-size', '-s', default='62', help='The label size (and kind) to use. Check available ones with `brother_ql_info list-label-sizes`.')
     parser.add_argument('--rotate', '-r', choices=('0', '90', '180', '270'), default='auto', help='Rotate the image (counterclock-wise) by this amount of degrees.')
-    parser.add_argument('--threshold', '-t', type=float, default=70.0, help='The threshold value (in percent) to discriminate between black and white pixels.')
+    parser.add_argument('--threshold', '-t', type=float, default=30.0, help='The threshold value (in percent) to discriminate between black and white pixels.')
     parser.add_argument('--no-cut', dest='cut', action='store_false', help="Don't cut the tape after printing the label.")
     parser.add_argument('--loglevel', type=lambda x: getattr(logging, x), default=logging.WARNING, help='Set to DEBUG for verbose debugging output to stderr.')
     parser.add_argument('--cores', '-c', type=int, default=defaultCores, help='The number of cores to use on creating the bin file.')
@@ -65,7 +65,7 @@ def main():
 
     args.outfile.write(qlr.data)
 
-def create_label(qlr, image, label_size, cores, threshold=70, cut=True, **kwargs):
+def create_label(qlr, image, label_size, cores, threshold=30, cut=True, **kwargs):
 
     label_specs = label_type_specs[label_size]
     dots_printable = label_specs['dots_printable']

--- a/brother_ql/brother_ql_create.py
+++ b/brother_ql/brother_ql_create.py
@@ -5,10 +5,13 @@ from __future__ import division
 import sys, argparse, logging
 
 from PIL import Image
+import PIL.ImageOps
 
 from brother_ql.raster import BrotherQLRaster
 from brother_ql.devicedependent import models, label_type_specs, ENDLESS_LABEL, DIE_CUT_LABEL, ROUND_DIE_CUT_LABEL
 from brother_ql import BrotherQLError, BrotherQLUnsupportedCmd, BrotherQLUnknownModel
+
+import multiprocessing
 
 try:
     stdout = sys.stdout.buffer
@@ -23,6 +26,9 @@ except:
 logger = logging.getLogger(__name__)
 
 def main():
+
+    defaultCores = multiprocessing.cpu_count()
+
     parser = argparse.ArgumentParser()
     parser.add_argument('image', help='The image file to create a label from.')
     parser.add_argument('outfile', nargs='?', type=argparse.FileType('wb'), default=stdout, help='The file to write the instructions to. Defaults to stdout.')
@@ -32,6 +38,7 @@ def main():
     parser.add_argument('--threshold', '-t', type=float, default=70.0, help='The threshold value (in percent) to discriminate between black and white pixels.')
     parser.add_argument('--no-cut', dest='cut', action='store_false', help="Don't cut the tape after printing the label.")
     parser.add_argument('--loglevel', type=lambda x: getattr(logging, x), default=logging.WARNING, help='Set to DEBUG for verbose debugging output to stderr.')
+    parser.add_argument('--cores', '-c', type=int, default=defaultCores, help='The number of cores to use on creating the bin file.')
     args = parser.parse_args()
 
     logging.basicConfig(level=args.loglevel)
@@ -51,11 +58,14 @@ def main():
 
     qlr.exception_on_warning = True
 
-    create_label(qlr, args.image, args.label_size, threshold=args.threshold, cut=args.cut, rotate=args.rotate)
+    coresMessage = "Attempting to create using " + str(args.cores) + " cores."
+    logger.debug(coresMessage)
+
+    create_label(qlr, args.image, args.label_size, cores=args.cores, threshold=args.threshold, cut=args.cut, rotate=args.rotate)
 
     args.outfile.write(qlr.data)
 
-def create_label(qlr, image, label_size, threshold=70, cut=True, **kwargs):
+def create_label(qlr, image, label_size, cores, threshold=70, cut=True, **kwargs):
 
     label_specs = label_type_specs[label_size]
     dots_printable = label_specs['dots_printable']
@@ -100,6 +110,7 @@ def create_label(qlr, image, label_size, threshold=70, cut=True, **kwargs):
         new_im.paste(im, (device_pixel_width-im.size[0]-right_margin_dots, 0))
         im = new_im
 
+    im = PIL.ImageOps.invert(im)
     threshold = min(255, max(0, int(threshold/100.0 * 255))) # from percent to pixel val
     im = im.point(lambda x: 0 if x < threshold else 255, mode="1")
 
@@ -142,7 +153,7 @@ def create_label(qlr, image, label_size, threshold=70, cut=True, **kwargs):
         qlr.add_compression(True)
     except BrotherQLUnsupportedCmd:
         pass
-    qlr.add_raster_data(im)
+    qlr.add_raster_data(im, cores)
     qlr.add_print()
 
 if __name__ == "__main__":

--- a/brother_ql/brother_ql_create.py
+++ b/brother_ql/brother_ql_create.py
@@ -35,7 +35,7 @@ def main():
     parser.add_argument('--model', '-m', default='QL-500', help='The printer model to use. Check available ones with `brother_ql_info list-models`.')
     parser.add_argument('--label-size', '-s', default='62', help='The label size (and kind) to use. Check available ones with `brother_ql_info list-label-sizes`.')
     parser.add_argument('--rotate', '-r', choices=('0', '90', '180', '270'), default='auto', help='Rotate the image (counterclock-wise) by this amount of degrees.')
-    parser.add_argument('--threshold', '-t', type=float, default=30.0, help='The threshold value (in percent) to discriminate between black and white pixels.')
+    parser.add_argument('--threshold', '-t', type=float, default=70.0, help='The threshold value (in percent) to discriminate between black and white pixels.')
     parser.add_argument('--no-cut', dest='cut', action='store_false', help="Don't cut the tape after printing the label.")
     parser.add_argument('--loglevel', type=lambda x: getattr(logging, x), default=logging.WARNING, help='Set to DEBUG for verbose debugging output to stderr.')
     parser.add_argument('--cores', '-c', type=int, default=defaultCores, help='The number of cores to use on creating the bin file.')
@@ -65,7 +65,7 @@ def main():
 
     args.outfile.write(qlr.data)
 
-def create_label(qlr, image, label_size, cores, threshold=30, cut=True, **kwargs):
+def create_label(qlr, image, label_size, cores, threshold=70, cut=True, **kwargs):
 
     label_specs = label_type_specs[label_size]
     dots_printable = label_specs['dots_printable']
@@ -111,6 +111,8 @@ def create_label(qlr, image, label_size, cores, threshold=30, cut=True, **kwargs
         im = new_im
 
     im = PIL.ImageOps.invert(im)
+
+    threshold = 100.0 - threshold
     threshold = min(255, max(0, int(threshold/100.0 * 255))) # from percent to pixel val
     im = im.point(lambda x: 0 if x < threshold else 255, mode="1")
 


### PR DESCRIPTION
Hi, @pklaus.
Thank you for creating this package, it really saved my day a couple of weeks ago.
I managed to get some time today and implemented the changes, including an extra command line parameter. I also took your suggestion and defaulted to the number of cores of the machine. You can pass that param with the --cores (or -c) option.

There's one detail with the implementation: the image inverting is done earlier now, so the threshold gets reversed (when you used 70 before, now you need a threshold of 30 to achieve the same result). Also, it depends on PIL.ImageOps, which I had to import. Other further imports are those concerning multiprocessing that I added to the raster file.