### PR TITLE
Readme updates for QL-800

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ In more details, the following is possible with this package:
 
 The following printers are claimed to be supported (✓ means verified by the author or by contributors):
 
-* QL-500 (✓), QL-550 (✓), QL-560, QL-570 (✓), QL-580N, QL-650TD, QL-700 (✓), QL-710W (✓), QL-720NW (✓), QL-800, QL-810W, QL-820NWB (✓), QL-1050, and QL-1060N.
+* QL-500 (✓), QL-550 (✓), QL-560, QL-570 (✓), QL-580N, QL-650TD, QL-700 (✓), QL-710W (✓), QL-720NW (✓), QL-800 (✓), QL-810W, QL-820NWB (✓), QL-1050, and QL-1060N.
 
 The new QL-800 series can print labels with two colors (black and red) on DK-22251 labels.
 
@@ -90,8 +90,10 @@ giving:
                             set, --threshold is meaningless.
       --compress, -c        Enable compression (if available with the model).
                             Takes more time but results in smaller file size.
-      --red                 Create a label to be printed in black/red/white (only
-                            with QL-800, QL-810W, QL-820NWB on DK-22251 labels).
+      --red                 Create a label to be printed on black/red/white tape
+                            (only with QL-8xx series on DK-22251 labels). You must
+                            use this option when printing on black/red tape, even
+                            when not printing red.
       --no-cut              Don't cut the tape after printing the label.
       --loglevel LOGLEVEL   Set to DEBUG for verbose debugging output to stderr.
 
@@ -156,7 +158,7 @@ You can also use the tool `brother_ql_print` (Py3 only) to send the instructions
 
 If your printer has problems printing the instructions file, it may blink its LED (green or red) depending on the model. This can have many reasons, eg.:
 
-* The selected label doesn't match.
+* The selected label doesn't match (make sure `--red` has been passed to `brother_ql_create` if you're using black/red labels).
 * End of paper.
 * Unsupported opcode (wrong `--model` when using `brother_ql_create`?)
 

--- a/brother_ql/brother_ql_create.py
+++ b/brother_ql/brother_ql_create.py
@@ -34,7 +34,7 @@ def main():
     parser.add_argument('--threshold', '-t', type=float, default=70.0, help='The threshold value (in percent) to discriminate between black and white pixels.')
     parser.add_argument('--dither', '-d', action='store_true', help='Enable dithering when converting the image to b/w. If set, --threshold is meaningless.')
     parser.add_argument('--compress', '-c', action='store_true', help='Enable compression (if available with the model). Takes more time but results in smaller file size.')
-    parser.add_argument('--red', action='store_true', help='Create a label to be printed in black/red/white (only with QL-800, QL-810W, QL-820NWB on DK-22251 labels).')
+    parser.add_argument('--red', action='store_true', help='Create a label to be printed on black/red/white tape (only with QL-8xx series on DK-22251 labels). You must use this option when printing on black/red tape, even when not printing red.')
     parser.add_argument('--no-cut', dest='cut', action='store_false', help="Don't cut the tape after printing the label.")
     parser.add_argument('--loglevel', type=lambda x: getattr(logging, x), default=logging.WARNING, help='Set to DEBUG for verbose debugging output to stderr.')
     args = parser.parse_args()


### PR DESCRIPTION
This seems to work fine on the QL-800, thanks! I've added a tick against
it.

I've also slightly updated the help for `brother_ql_create` to make it
clear that you have to enable the --red option to print on tape which
supports red, otherwise the printer reports an error.

(This happens with the P-Touch software too and it's really unclear what
you're doing wrong.)