### PR TITLE
Update README to note editor lite problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ In more details, the following is possible with this package:
 The following printers are claimed to be supported (✓ means verified by the author or by contributors):
 
 * QL-500 (✓), QL-550 (✓), QL-560, QL-570 (✓), QL-580N, QL-650TD, QL-700 (✓), QL-710W (✓), QL-720NW (✓), QL-800 (✓), QL-810W, QL-820NWB (✓), QL-1050, and QL-1060N.
+* Note: If your printer has an 'Editor Lite' light, you will most likely need to make sure it is not lit by holding the button down until it turns off.
+  If the light is on, your device may show up as a usb-storage device rather than a usblp device.
 
 The new QL-800 series can print labels with two colors (black and red) on DK-22251 labels.
 


### PR DESCRIPTION
As I was attempting to setup my QL-800 I ran an issue where my printer was showing up as a usb-storage device as opposed to a usblp device and was having a difficult time figuring out why.  I happen to run across an old support thread for the QL-700 which someone had a different problem but the solution recommended making sure the 'Editor Lite' light was off, so I gave it a shot and it solved my problem as well.

Just wanted to try and pass along my experience in case it may save someone else time down the road.