### PR TITLE
Typo: images -> image

### DIFF
--- a/brother_ql/conversion.py
+++ b/brother_ql/conversion.py
@@ -81,7 +81,7 @@ def convert(qlr, images, label,  **kwargs):
         pass
 
     for image in images:
-        if isinstance(images, Image.Image):
+        if isinstance(image, Image.Image):
             im = image
         elif isinstance(image, (unicode, str)):
             im = Image.open(image)


### PR DESCRIPTION
Check if the image is an instance of Image.Image, instead of the list containing the images.