### PR TITLE
Make all packages available for import

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 try:
-    from setuptools import setup
+    from setuptools import find_packages, setup
 except ImportError:
     from distutils.core import setup
 
@@ -22,8 +22,7 @@ setup(name='brother_ql',
       author_email = 'philipp.l.klaus@web.de',
       url = 'https://github.com/pklaus/brother_ql',
       license = 'GPL',
-      packages = ['brother_ql',
-                  'brother_ql.backends'],
+      packages = find_packages(),
       entry_points = {
           'console_scripts': [
               'brother_ql = brother_ql.cli:cli',


### PR DESCRIPTION
Hi! I like the work on this package very much and I have been using it in other python projects by calling the commands with subprocess.
However, I would like now to directly call the brother_ql internal functions and avoid subprocess, as this makes its usage complicated in frozen applications (pyinstaller) and/or Windows OS.
Even CLI centric projects such as pipenv usually include all available packages on installation (except of testing), so the user can freely use internal functions as they want.