### PR TITLE
Adding support for 103mm endless labels (DK22246, named "104")

### DIFF
--- a/brother_ql/labels.py
+++ b/brother_ql/labels.py
@@ -89,6 +89,7 @@ ALL_LABELS = (
   Label("62",     ( 62,   0), FormFactor.ENDLESS,       ( 732,    0), ( 696,    0),  12 , feed_margin=35),
   Label("62red",  ( 62,   0), FormFactor.ENDLESS,       ( 732,    0), ( 696,    0),  12 , feed_margin=35, color=Color.BLACK_RED_WHITE),
   Label("102",    (102,   0), FormFactor.ENDLESS,       (1200,    0), (1164,    0),  12 , feed_margin=35, restricted_to_models=['QL-1050', 'QL-1060N']),
+  Label("104",    (104,   0), FormFactor.ENDLESS,       (1227,    0), (1200,    0),  -8 , feed_margin=35, restricted_to_models=['QL-1050', 'QL-1100']),
   Label("17x54",  ( 17,  54), FormFactor.DIE_CUT,       ( 201,  636), ( 165,  566),   0 ),
   Label("17x87",  ( 17,  87), FormFactor.DIE_CUT,       ( 201, 1026), ( 165,  956),   0 ),
   Label("23x23",  ( 23,  23), FormFactor.DIE_CUT,       ( 272,  272), ( 202,  202),  42 ),


### PR DESCRIPTION
This change is based on #88 

I have tested the endless paper rolls with my QL1050 and it works without any problems.

I've used the "conservative" approach mentioned in the issue and added a feed margin