### PR TITLE
Use 400 byte invalidate command for QL-8XX models.

### DIFF
--- a/brother_ql/models.py
+++ b/brother_ql/models.py
@@ -35,6 +35,8 @@ class Model(object):
     #: Support for two color printing (black/red/white)
     #: available only on some newer models.
     two_color = attrib(type=bool, default=False)
+    #: Number of NULL bytes needed for the invalidate command.
+    num_invalidate_bytes = attrib(type=int, default=200)
 
     @property
     def name(self):
@@ -50,9 +52,9 @@ ALL_MODELS = [
   Model('QL-700',   (150, 11811), compression=False, mode_setting=False),
   Model('QL-710W',  (150, 11811)),
   Model('QL-720NW', (150, 11811)),
-  Model('QL-800',   (150, 11811), two_color=True, compression=False),
-  Model('QL-810W',  (150, 11811), two_color=True),
-  Model('QL-820NWB',(150, 11811), two_color=True),
+  Model('QL-800',   (150, 11811), two_color=True, compression=False, num_invalidate_bytes=400),
+  Model('QL-810W',  (150, 11811), two_color=True, num_invalidate_bytes=400),
+  Model('QL-820NWB',(150, 11811), two_color=True, num_invalidate_bytes=400),
   Model('QL-1050',  (295, 35433), number_bytes_per_row=162, additional_offset_r=44),
   Model('QL-1060N', (295, 35433), number_bytes_per_row=162, additional_offset_r=44),
   Model('PT-P750W',  (31, 14172), number_bytes_per_row=16),

--- a/brother_ql/raster.py
+++ b/brother_ql/raster.py
@@ -16,6 +16,7 @@ import packbits
 from PIL import Image
 import io
 
+from brother_ql.models import ModelsManager
 from .devicedependent import models, \
                              min_max_feed, \
                              min_max_length_dots, \
@@ -64,6 +65,12 @@ class BrotherQLRaster(object):
         self.two_color_printing = False
         self._compression = False
         self.exception_on_warning = False
+
+        self.num_invalidate_bytes = 200
+        for m in ModelsManager().iter_elements():
+            if self.model == m.identifier:
+                self.num_invalidate_bytes = m.num_invalidate_bytes
+                break
 
     def _warn(self, problem, kind=BrotherQLRasterError):
         """
@@ -114,7 +121,7 @@ class BrotherQLRaster(object):
 
     def add_invalidate(self):
         """ clear command buffer """
-        self.data += b'\x00' * 200
+        self.data += b'\x00' * self.num_invalidate_bytes
 
     @property
     def mtype(self): return self._mtype


### PR DESCRIPTION
QL-800, QL-810W, and QL-820NWB need 400 byte long invalidate commands, as seen on page 5 of the manual [1].

This PR specifically avoids the use of the deprecated `devicedependent` module.

[1] https://download.brother.com/welcome/docp100278/cv_ql800_eng_raster_100.pdf