### PR TITLE
update for PT-P950NW

### DIFF
--- a/brother_ql/labels.py
+++ b/brother_ql/labels.py
@@ -82,6 +82,7 @@ class Label(object):
 
 ALL_LABELS = (
   Label("12",     ( 12,   0), FormFactor.ENDLESS,       ( 142,    0), ( 106,    0),  29 , feed_margin=35),
+  Label("18",     ( 18,   0), FormFactor.ENDLESS,       ( 256,    0), ( 234,    0), 171 , feed_margin=14),
   Label("29",     ( 29,   0), FormFactor.ENDLESS,       ( 342,    0), ( 306,    0),   6 , feed_margin=35),
   Label("38",     ( 38,   0), FormFactor.ENDLESS,       ( 449,    0), ( 413,    0),  12 , feed_margin=35),
   Label("50",     ( 50,   0), FormFactor.ENDLESS,       ( 590,    0), ( 554,    0),  12 , feed_margin=35),

--- a/brother_ql/models.py
+++ b/brother_ql/models.py
@@ -57,6 +57,7 @@ ALL_MODELS = [
   Model('QL-1060N', (295, 35433), number_bytes_per_row=162, additional_offset_r=44),
   Model('PT-P750W',  (31, 14172), number_bytes_per_row=16),
   Model('PT-P900W',  (57, 28346), number_bytes_per_row=70),
+  Model('PT-P950NW',  (57, 28346), number_bytes_per_row=70),
 ]
 
 class ModelsManager(ElementsManager):

--- a/brother_ql/reader.py
+++ b/brother_ql/reader.py
@@ -33,6 +33,7 @@ OPCODES = {
     b'\x1b\x69\x55\x77\x01': ('amedia',        127, "Additional media information command"),
     b'\x1b\x69\x55\x4A':     ('jobid',          14, "Job ID setting command"),
     b'\x1b\x69\x58\x47':     ("request_config",  0, "Request transmission of .ini config file of printer"),
+    b'\x1b\x69\x6B\x63':     ("number_of_copies",  2, "Internal specification commands"),
     b'\x1b\x69\x53':         ('status request',  0, "A status information request sent to the printer"),
     b'\x80\x20\x42':         ('status response',29, "A status response received from the printer"),
 }


### PR DESCRIPTION
Thank you very much for all the efforts on label printers ! I just made it worked with PT-P950NW and 18mm labels and so I'm trying to contribute back the setting that I used.

Originally I failed without the compression flag. The following is the results,

![IMG_9797](https://user-images.githubusercontent.com/2705921/113796082-59552c80-9789-11eb-9ae2-f41b48cc33e2.jpg)

```shell
# works (left)
brother_ql_create -c -m PT-P950NW --label-size 18 ~/Desktop/label_tests/mspaint_test_rotated.png > mspaint_gen3.bin
brother_ql --debug -m PT-P950NW -p usb://0x04f9:0x2086/000M7Z552861 send mspaint_gen3.bin

# works (left)
brother_ql --debug -m PT-P950NW -p usb://0x04f9:0x2086/000M7Z552861 print -c -l 18 ~/Desktop/label_tests/mspaint_test_rotated.png

# doesn't work (right)
brother_ql --debug -m PT-P950NW -p usb://0x04f9:0x2086/000M7Z552861 print -l 18 ~/Desktop/label_tests/mspaint_test_rotated.png
```

This is the original image,

![mspaint_test_rotated](https://user-images.githubusercontent.com/2705921/113796073-56f2d280-9789-11eb-90ee-5072916d17bc.png)

There are a few points that I would like to mention when I was playing with the commands,

* The `number_of_copies` update in the opcode list is because when I tried to analyze the binary generated by the printing utility, it found an unknown command. Maybe it's a new command that is only on PT-P900 series ?
* Originally I had the image in landscape, width of the image is longer than height, as I thought that's the default way, or at least the auto rotate will help me do the tricks. In the end, I just rotated the image manually.
* As PT-P950NW changed to 360dpi x 360dpi, I was confused by those `converting to 300dpi` wording in the readme and in the code, but I realized that the code is just trying to resize the image to the target width pixel.

Thanks again for the nice code base :)

