### PR TITLE
Add required=True to image path argument in print subcommand

### DIFF
--- a/brother_ql/cli.py
+++ b/brother_ql/cli.py
@@ -120,7 +120,7 @@ def env(ctx, *args, **kwargs):
     print("\n##################\n")
 
 @cli.command('print', short_help='Print a label')
-@click.argument('images', nargs=-1, type=click.File('rb'), metavar='IMAGE [IMAGE] ...')
+@click.argument('images', nargs=-1, required=True, type=click.File('rb'), metavar='IMAGE [IMAGE] ...')
 @click.option('-l', '--label', type=click.Choice(label_sizes), envvar='BROTHER_QL_LABEL', help='The label (size, type - die-cut or endless). Run `brother_ql info labels` for a full list including ideal pixel dimensions.')
 @click.option('-r', '--rotate', type=click.Choice(('auto', '0', '90', '180', '270')), default='auto', help='Rotate the image (counterclock-wise) by this amount of degrees.')
 @click.option('-t', '--threshold', type=float, default=70.0, help='The threshold value (in percent) to discriminate between black and white pixels.')


### PR DESCRIPTION
Added required=True tag to ensure that the print subcommand does not continue forward with the print process when no file path is provided. Changes were verified by connecting to brother-ql 810W and running the following command and checking that it (correctly) fails:
`sudo env PATH=$PATH ./cli.py -b pyusb -m QL-810W -p usb://0x04f9:0x209c --debug print -l 62`
For regression testing, the command was attempted again with a valid file path and checked that the printer successfully prints.