### PR TITLE
Added QL-600

### DIFF
--- a/brother_ql/models.py
+++ b/brother_ql/models.py
@@ -57,6 +57,7 @@ ALL_MODELS = [
   Model('QL-1060N', (295, 35433), number_bytes_per_row=162, additional_offset_r=44),
   Model('PT-P750W',  (31, 14172), number_bytes_per_row=16),
   Model('PT-P900W',  (57, 28346), number_bytes_per_row=70),
+  Model('QL-600',   (150, 11811), compression=False, mode_setting=True),
 ]
 
 class ModelsManager(ElementsManager):

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ except (ImportError, IOError, RuntimeError) as e:
     LDESC = ''
 
 setup(name='brother_ql',
-      version = '0.9.dev0',
+      version = '0.9.dev1',
       description = 'Python package to talk to Brother QL label printers',
       long_description = LDESC,
       author = 'Philipp Klaus',


### PR DESCRIPTION
I have a QL-600 and added the corresponding model data. It uses a different release of ttheir Command Reference (https://download.brother.com/welcome/docp000698/cv_ql600710720_eng_raster_102.pdf to be exact), but works flawlessly.

I did add a `save` command which saves the generated instructions to a file (e.g. to be used with the `send` command), but I'm willing to create a pull request without that