### PR TITLE
Support 54x29 Label (DK-3235)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The most important command is the `print` command and here is its CLI signature:
       Print a label of the provided IMAGE.
     
     Options:
-      -l, --label [12|29|38|50|54|62|102|17x54|17x87|23x23|29x42|29x90|39x90|39x48|52x29|62x29|62x100|102x51|102x152|d12|d24|d58]
+      -l, --label [12|29|38|50|54|62|102|17x54|17x87|23x23|29x42|29x90|39x90|39x48|52x29|54x29|62x29|62x100|102x51|102x152|d12|d24|d58]
                                       The label (size, type - die-cut or endless).
                                       Run `brother_ql info labels` for a full
                                       list including ideal pixel dimensions.
@@ -151,6 +151,7 @@ The available label names can be listed with `brother_ql info labels`:
      39x90      413 x  991    38mm x 90mm die-cut
      39x48      425 x  495    39mm x 48mm die-cut
      52x29      578 x  271    52mm x 29mm die-cut
+     54x29      598 x  271    54mm x 29mm die-cut
      62x29      696 x  271    62mm x 29mm die-cut
      62x100     696 x 1109    62mm x 100mm die-cut
      102x51    1164 x  526    102mm x 51mm die-cut

--- a/brother_ql/labels.py
+++ b/brother_ql/labels.py
@@ -97,6 +97,7 @@ ALL_LABELS = (
   Label("39x90",  ( 38,  90), FormFactor.DIE_CUT,       ( 449, 1061), ( 413,  991),  12 ),
   Label("39x48",  ( 39,  48), FormFactor.DIE_CUT,       ( 461,  565), ( 425,  495),   6 ),
   Label("52x29",  ( 52,  29), FormFactor.DIE_CUT,       ( 614,  341), ( 578,  271),   0 ),
+  Label("54x29",  ( 54,  29), FormFactor.DIE_CUT,       ( 630,  341), ( 598,  271),  60 ),
   Label("62x29",  ( 62,  29), FormFactor.DIE_CUT,       ( 732,  341), ( 696,  271),  12 ),
   Label("62x100", ( 62, 100), FormFactor.DIE_CUT,       ( 732, 1179), ( 696, 1109),  12 ),
   Label("102x51", (102,  51), FormFactor.DIE_CUT,       (1200,  596), (1164,  526),  12 , restricted_to_models=['QL-1050', 'QL-1060N']),


### PR DESCRIPTION
Support 54x29 Label (DK-3235 - Removable)
![E1C6BACC-2483-47C5-843F-A6DADB0E2CA5](https://user-images.githubusercontent.com/2618822/135699877-bf48247b-dfa0-452f-9c90-8cef6bc886bc.JPG)

![99D7E25B-5B0C-4BC2-B5F0-15650AB45E02](https://user-images.githubusercontent.com/2618822/135699878-6c33c01a-4c60-4b55-b52b-7edb80b4ba42.JPG)

