### PR TITLE
Fix ValueError: invalid literal for int() with base 16

### DIFF
--- a/brother_ql/backends/pyusb.py
+++ b/brother_ql/backends/pyusb.py
@@ -48,7 +48,7 @@ def list_available_devices():
     def identifier(dev):
         try:
             serial = usb.util.get_string(dev, 256, dev.iSerialNumber)
-            return 'usb://0x{:04x}:0x{:04x}_{}'.format(dev.idVendor, dev.idProduct, serial)
+            return 'usb://0x{:04x}:0x{:04x}/{}'.format(dev.idVendor, dev.idProduct, serial)
         except:
             return 'usb://0x{:04x}:0x{:04x}'.format(dev.idVendor, dev.idProduct)
 


### PR DESCRIPTION
The `identifier()` function previously returned the serial number separated with an underscore "_", whereas `BrotherQLBackendPyUSB.__init__()` expects the device_specifier to separate the serial number with a forward slash "/". This was causing the following error to be raised when a serial number is present for the printer:

    ValueError: invalid literal for int() with base 16