### PR TITLE
Manage two or more printers of the same model

### DIFF
--- a/brother_ql/backends/helpers.py
+++ b/brother_ql/backends/helpers.py
@@ -67,7 +67,7 @@ def send(instructions, printer_identifier=None, backend_identifier=None, blockin
         """ No need to wait for completion. The network backend doesn't support readback. """
         return status
 
-    while time.time() - start < 10:
+    while time.time() - start < 60:
         data = printer.read()
         if not data:
             time.sleep(0.005)


### PR DESCRIPTION
The library seems to conflict when two devices of the same model are used (via USB). I edit `brother_ql/backends/pyusb.py` to make it work in this scenario.