### PR TITLE
[fix] "Pillow renamed ANTIALIAS to LANCZOS"

### DIFF
--- a/brother_ql/conversion.py
+++ b/brother_ql/conversion.py
@@ -110,7 +110,7 @@ def convert(qlr, images, label,  **kwargs):
                 im = im.resize((im.size[0]//2, im.size[1]))
             if im.size[0] != dots_printable[0]:
                 hsize = int((dots_printable[0] / im.size[0]) * im.size[1])
-                im = im.resize((dots_printable[0], hsize), Image.ANTIALIAS)
+                im = im.resize((dots_printable[0], hsize), Image.LANCZOS)
                 logger.warning('Need to resize the image...')
             if im.size[0] < device_pixel_width:
                 new_im = Image.new(im.mode, (device_pixel_width, im.size[1]), (255,)*len(im.mode))


### PR DESCRIPTION
fixes #142

Pillow renamed ANTIALIAS to LANCZOS in version [2.7.0][1]. This will break installations using older versions. Pillow 2.7.0 was released almost ten years ago, this should be acceptable.  

  [1]: https://github.com/python-pillow/Pillow/blob/main/docs/releasenotes/2.7.0.rst#antialias-renamed-to-lanczos