### PR TITLE
Replace ANTIALIAS with LANCZOS

### DIFF
--- a/brother_ql/conversion.py
+++ b/brother_ql/conversion.py
@@ -110,7 +110,7 @@ def convert(qlr, images, label,  **kwargs):
                 im = im.resize((im.size[0]//2, im.size[1]))
             if im.size[0] != dots_printable[0]:
                 hsize = int((dots_printable[0] / im.size[0]) * im.size[1])
-                im = im.resize((dots_printable[0], hsize), Image.ANTIALIAS)
+                im = im.resize((dots_printable[0], hsize), Image.LANCZOS)
                 logger.warning('Need to resize the image...')
             if im.size[0] < device_pixel_width:
                 new_im = Image.new(im.mode, (device_pixel_width, im.size[1]), (255,)*len(im.mode))


### PR DESCRIPTION
Hello, I was using your python package and I noticed that on my new configuration, it has started returning errors:
```sh
deprecation warning: brother_ql.devicedependent is deprecated and will be removed in a future release
Traceback (most recent call last):
  File ".../brother_ql", line 8, in <module>
    sys.exit(cli())
  File "/usr/lib/python3/dist-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python3/dist-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python3/dist-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python3/dist-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/user/.local/lib/python3.10/site-packages/brother_ql/cli.py", line 146, in print_cmd
    instructions = convert(qlr=qlr, **kwargs)
  File "/home/user/.local/lib/python3.10/site-packages/brother_ql/conversion.py", line 112, in convert
    im = im.resize((dots_printable[0], hsize), Image.ANTIALIAS)
AttributeError: module 'PIL.Image' has no attribute 'ANTIALIAS'
```
After investigating, I found the following:
> ANTIALIAS was removed in Pillow 10.0.0 (after being deprecated through many previous versions). Now you need to use PIL.Image.LANCZOS or PIL.Image.Resampling.LANCZOS.

[Source](https://stackoverflow.com/questions/76616042/attributeerror-module-pil-image-has-no-attribute-antialias)

I temporarily reverted to version 9.5 of Pillow, but I thought that it would be nice to create a pull request as well.

Best regards,
Angel