### PR TITLE
Fix Pillow `Image.ANTIALIAS` depreciation

### DIFF
--- a/brother_ql/conversion.py
+++ b/brother_ql/conversion.py
@@ -110,7 +110,7 @@ def convert(qlr, images, label,  **kwargs):
                 im = im.resize((im.size[0]//2, im.size[1]))
             if im.size[0] != dots_printable[0]:
                 hsize = int((dots_printable[0] / im.size[0]) * im.size[1])
-                im = im.resize((dots_printable[0], hsize), Image.ANTIALIAS)
+                im = im.resize((dots_printable[0], hsize), Image.LANCZOS)
                 logger.warning('Need to resize the image...')
             if im.size[0] < device_pixel_width:
                 new_im = Image.new(im.mode, (device_pixel_width, im.size[1]), (255,)*len(im.mode))


### PR DESCRIPTION
Pillow removed `Image.ANTIALIAS` in 10.0 [Release Notes](https://pillow.readthedocs.io/en/stable/releasenotes/10.0.0.html#constants).

This change updates the deprecated `Image.ANTIALIAS` to the replaced function `Image.LANCZOS`