### PR TITLE
Add 103x164 for QL-1060N

### DIFF
--- a/brother_ql/labels.py
+++ b/brother_ql/labels.py
@@ -101,6 +101,7 @@ ALL_LABELS = (
   Label("62x100", ( 62, 100), FormFactor.DIE_CUT,       ( 732, 1179), ( 696, 1109),  12 ),
   Label("102x51", (102,  51), FormFactor.DIE_CUT,       (1200,  596), (1164,  526),  12 , restricted_to_models=['QL-1050', 'QL-1060N']),
   Label("102x152",(102, 153), FormFactor.DIE_CUT,       (1200, 1804), (1164, 1660),  12 , restricted_to_models=['QL-1050', 'QL-1060N']),
+  Label("103x164",(103, 164), FormFactor.DIE_CUT,       (1211, 1933), (1175, 1779),  12 , restricted_to_models=['QL-1050', 'QL-1060N']),
   Label("d12",    ( 12,  12), FormFactor.ROUND_DIE_CUT, ( 142,  142), (  94,   94), 113 , feed_margin=35),
   Label("d24",    ( 24,  24), FormFactor.ROUND_DIE_CUT, ( 284,  284), ( 236,  236),  42 ),
   Label("d58",    ( 58,  58), FormFactor.ROUND_DIE_CUT, ( 688,  688), ( 618,  618),  51 ),


### PR DESCRIPTION
Regarding #160 I thought it might be worth adding a PR.

I have not tested this. Here is the rationale as to how I came up with the numbers added for 103x164 label sizes:

1. Take the ratios of the existing labels for that printer (1200/102=11.76470588 <-- this being the ratio)
2. Extrapolate all the other ratios
3. Apply the closest existing dimension to the new ones (103 ~ 102 & 164 ~ 152)
4. Apply the ratios
5. Round down

Perhaps there is some documented number or is it a bit of test and repeat?

Label Dimension|Ratio|Dots
-- | -- | --
102 | 11.76470588 | 1200
51 | 11.68627451 | 596
153 | 11.79084967 | 1804
102 | 11.41176471 | 1164
51 | 10.31372549 | 526
153 | 10.8496732 | 1660
  |   |  
  |   |  
103 | 11.76470588 | 1211.764706
164 | 11.79084967 | 1933.699346
103 | 11.41176471 | 1175.411765
164 | 10.8496732 | 1779.346405